### PR TITLE
VS-1557: Allow unstructuring of attrs classes in typing.Any-typed fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v2.0.2
+
+- Fixes regression in post cattrs-1.1.2 where attrs objects in `typing.Any` fields are
+  returned as-is and not unstructured
+
 ## v2.0.1
 
 - Fixes error in structuring parameterized generic wildcats

--- a/tests/test_try_struc.py
+++ b/tests/test_try_struc.py
@@ -1,0 +1,19 @@
+from typecats import Cat, try_struc
+
+
+def test_with_no_default():
+    @Cat
+    class Thing(dict):
+        name: str
+
+    assert try_struc(Thing, None) is None
+    assert Thing.try_struc(None) is None
+
+
+def test_with_default():
+    @Cat
+    class Thing(dict):
+        name: str = ""
+
+    assert try_struc(Thing, None) is None
+    assert Thing.try_struc(None) is None

--- a/tests/test_unstruc_any.py
+++ b/tests/test_unstruc_any.py
@@ -1,0 +1,71 @@
+import typing as ty
+
+from typecats import Cat, register_unstruc_hook_func
+
+
+@Cat
+class Container:
+    one: ty.Any
+    many: ty.List[ty.Any]
+
+
+@Cat
+class SecondContainer:
+    thing: ty.Any
+
+
+@Cat
+class SomeCat:
+    field: str
+
+
+class HasUnstrucHook:
+    def __init__(self, unstruc_field):
+        self.unstruc_field = unstruc_field
+
+
+class WithoutUnstrucHook:
+    def __init__(self, some_field):
+        self.some_field = some_field
+
+
+def test_unstruc_cat_types_in_any_fields():
+    container = Container(
+        one=SecondContainer(
+            thing=SomeCat(field="a"),
+        ),
+        many=[
+            SecondContainer(
+                thing=SomeCat(field="b"),
+            ),
+            SomeCat(field="c"),
+        ],
+    )
+
+    expected = {
+        "one": {"thing": {"field": "a"}},
+        "many": [{"thing": {"field": "b"}}, {"field": "c"}],
+    }
+
+    assert container.unstruc() == expected
+
+
+def test_unstruc_of_non_cat_in_any_field_with_unstruc_hook():
+    register_unstruc_hook_func(
+        lambda t: t == HasUnstrucHook, lambda x: {"unstruc_field": x.unstruc_field}
+    )
+
+    # This has no unstruc hook registered and should therefore be returned as-is
+    no_unstruc = WithoutUnstrucHook("some_str_0")
+
+    container = Container(
+        one=HasUnstrucHook("some_str_1"),
+        many=[no_unstruc, HasUnstrucHook("some_str_2")],
+    )
+
+    expected = {
+        "one": {"unstruc_field": "some_str_1"},
+        "many": [no_unstruc, {"unstruc_field": "some_str_2"}],
+    }
+
+    assert container.unstruc() == expected

--- a/typecats/__about__.py
+++ b/typecats/__about__.py
@@ -1,4 +1,4 @@
 """typecats"""
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __author__ = "Peter Gaultney"
 __author_email__ = "pgaultney@xoi.io"

--- a/typecats/patch.py
+++ b/typecats/patch.py
@@ -58,6 +58,20 @@ def unstructure_strip_defaults_factory(gen_converter: GenConverter, cls: type):
     return unstructure_strip_defaults
 
 
+def _is_any(cl: ty.Type) -> bool:
+    return cl == ty.Any
+
+
+def unstructure_any_from_runtime_type(
+    gen_converter: GenConverter, obj: ty.Any
+) -> ty.Union[ty.Any, dict]:
+    cls = type(obj)
+    if is_attrs_class(cls):
+        return gen_converter.unstructure(obj, cls)
+    else:
+        return gen_converter.unstructure(obj)
+
+
 def patch_converter_for_typecats(converter: GenConverter) -> GenConverter:
     if converter in __patched_converters:
         return converter
@@ -68,6 +82,10 @@ def patch_converter_for_typecats(converter: GenConverter) -> GenConverter:
 
     converter.register_unstructure_hook_factory(
         has_with_generic, partial(unstructure_strip_defaults_factory, converter)
+    )
+
+    converter.register_unstructure_hook_func(
+        _is_any, partial(unstructure_any_from_runtime_type, converter)
     )
 
     __patched_converters.append(converter)


### PR DESCRIPTION
This fixes a regression in cattrs >= 1.2.0: https://github.com/python-attrs/cattrs/issues/320. It is again a very naïve solution but fixes the regression here.