### PR TITLE
Fix: python 3.12 enum unstruc regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "typecats"
 description = "Structure unstructured data for the purpose of static type checking"
 authors = [{name = "Peter Gaultney", email = "pgaultney@xoi.io"}]
-version = "2.1.1"
+version = "2.1.2"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_behavioral.py
+++ b/tests/test_behavioral.py
@@ -536,3 +536,87 @@ def test_module_unstruc_and_method_unstruc_are_equivalent():
 
     obj = Thing("hello", 7)
     assert unstruc(obj) == obj.unstruc()
+
+
+# ---------------------------------------------------------------------------
+# Enum structuring
+# ---------------------------------------------------------------------------
+
+
+def test_cat_enum_structures_by_value():
+    """A @Cat Enum field must structure from its string value."""
+    from enum import Enum
+
+    @Cat
+    class Color(Enum):
+        RED = "RED"
+        GREEN = "GREEN"
+        BLUE = "BLUE"
+
+    @Cat
+    class Palette:
+        color: Color
+
+    obj = Palette.struc({"color": "GREEN"})
+    assert obj.color is Color.GREEN
+    assert obj.unstruc() == {"color": "GREEN"}
+
+
+def test_cat_enum_structures_nested_in_cat():
+    """Enum used as a field type in a nested @Cat class must round-trip."""
+    from enum import Enum
+
+    @Cat
+    class SortDateType(Enum):
+        CREATED_AT = "CREATED_AT"
+        COMPLETED_AT = "COMPLETED_AT"
+
+    @Cat
+    class DateQueryInput:
+        type: SortDateType
+
+    @Cat
+    class ListInput:
+        limit: int = 10
+        date_query: ty.Optional[DateQueryInput] = None
+
+    obj = ListInput.struc({"limit": 5, "date_query": {"type": "COMPLETED_AT"}})
+    assert obj.date_query is not None
+    assert obj.date_query.type is SortDateType.COMPLETED_AT
+    assert obj.unstruc() == {"limit": 5, "date_query": {"type": "COMPLETED_AT"}}
+
+
+def test_non_cat_enum_structures_in_cat_class():
+    """A plain (non-@Cat) Enum used as a field type must also structure correctly."""
+    from enum import Enum
+
+    class Priority(Enum):
+        LOW = "LOW"
+        HIGH = "HIGH"
+
+    @Cat
+    class Task:
+        name: str
+        priority: Priority
+
+    obj = Task.struc({"name": "fix bug", "priority": "HIGH"})
+    assert obj.priority is Priority.HIGH
+
+
+def test_cat_enum_with_int_values():
+    """@Cat Enum with integer values must structure from int."""
+    from enum import Enum
+
+    @Cat
+    class Status(Enum):
+        PENDING = 0
+        ACTIVE = 1
+        CLOSED = 2
+
+    @Cat
+    class Record:
+        status: Status
+
+    obj = Record.struc({"status": 1})
+    assert obj.status is Status.ACTIVE
+    assert obj.unstruc() == {"status": 1}

--- a/tests/test_behavioral.py
+++ b/tests/test_behavioral.py
@@ -620,3 +620,21 @@ def test_cat_enum_with_int_values():
     obj = Record.struc({"status": 1})
     assert obj.status is Status.ACTIVE
     assert obj.unstruc() == {"status": 1}
+
+
+def test_cat_enum_with_annotations_structures_by_value():
+    """A @Cat Enum with annotated members must still structure by value."""
+    from enum import Enum
+
+    @Cat
+    class AnnotatedEnum(Enum):
+        A: str = "a"
+        B: str = "b"
+
+    @Cat
+    class Container:
+        value: AnnotatedEnum
+
+    obj = Container.struc({"value": "a"})
+    assert obj.value is AnnotatedEnum.A
+    assert obj.unstruc() == {"value": "a"}

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -203,11 +203,7 @@ def Cat(
     """
 
     def _would_attrs_produce_fields(cls) -> bool:
-        if attr.has(cls):
-            return True
-        if kwargs.get("these"):
-            return True
-        return bool(cls.__dict__.get("__annotations__", {}))
+        return attr.has(cls) or bool(cls.__dict__.get("__annotations__", {}))
 
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
         if _would_attrs_produce_fields(cls):

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -6,7 +6,7 @@ from functools import partial
 import attr
 import cattrs
 
-from .attrs_shim import make_disallow_empties_transformer
+from .attrs_shim import FieldTransformer, make_disallow_empties_transformer
 from .converter import TypecatsConverter
 from .wildcat import (
     mixin_wildcat_post_attrs_methods,
@@ -148,6 +148,7 @@ def Cat(
     auto_attribs: bool = ...,
     disallow_empties: bool = ...,
     converter: TypecatsConverter = ...,
+    field_transformer: FieldTransformer | None = None,
     **kwargs: ty.Any,
 ) -> ty.Type[C]: ...
 
@@ -165,6 +166,7 @@ def Cat(
     auto_attribs: bool = ...,
     disallow_empties: bool = ...,
     converter: TypecatsConverter = ...,
+    field_transformer: FieldTransformer | None = None,
     **kwargs: ty.Any,
 ) -> ty.Callable[[ty.Type[C]], ty.Type[C]]: ...
 
@@ -174,6 +176,7 @@ def Cat(
     auto_attribs=True,
     disallow_empties=True,
     converter: TypecatsConverter = _TYPECATS_DEFAULT_CONVERTER,
+    field_transformer: FieldTransformer | None = None,
     **kwargs,
 ):
     """A Cat knows how to take care of itself.
@@ -207,14 +210,13 @@ def Cat(
 
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
         if _would_attrs_produce_fields(cls):
-            user_transformer = kwargs.get("field_transformer")
             cls = attr.attrs(
                 cls,
                 auto_attribs=auto_attribs,
                 field_transformer=make_disallow_empties_transformer(
-                    disallow_empties, user_transformer
+                    disallow_empties, field_transformer
                 ),
-                **{k: v for k, v in kwargs.items() if k != "field_transformer"},
+                **kwargs,
             )
             if is_wildcat(cls):
                 setup_warnings_for_dangerous_dict_subclass_operations(cls)

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -203,9 +203,9 @@ def Cat(
 
     """
 
-    # Classes that are incompatible with attr.attrs() when they have no fields.
-    # Enum: attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
-    _CLASSES_INCOMPATIBLE_WITH_ATTRS = (enum.Enum,)
+    _CLASSES_INCOMPATIBLE_WITH_ATTRS = (
+        enum.Enum,  # attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
+    )
 
     def _skip_attrs(cls) -> bool:
         return issubclass(cls, _CLASSES_INCOMPATIBLE_WITH_ATTRS)

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -202,20 +202,26 @@ def Cat(
 
     """
 
+    def _would_attrs_produce_fields(cls) -> bool:
+        if attr.has(cls):
+            return True
+        if kwargs.get("these"):
+            return True
+        return bool(cls.__dict__.get("__annotations__", {}))
+
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
-        # it is always safe to apply this attrs-class-making decorator,
-        # even if there's already an __attrs_attrs__ on a base class.
-        user_transformer = kwargs.get("field_transformer")
-        cls = attr.attrs(
-            cls,
-            auto_attribs=auto_attribs,
-            field_transformer=make_disallow_empties_transformer(
-                disallow_empties, user_transformer
-            ),
-            **{k: v for k, v in kwargs.items() if k != "field_transformer"},
-        )
-        if is_wildcat(cls):
-            setup_warnings_for_dangerous_dict_subclass_operations(cls)
+        if _would_attrs_produce_fields(cls):
+            user_transformer = kwargs.get("field_transformer")
+            cls = attr.attrs(
+                cls,
+                auto_attribs=auto_attribs,
+                field_transformer=make_disallow_empties_transformer(
+                    disallow_empties, user_transformer
+                ),
+                **{k: v for k, v in kwargs.items() if k != "field_transformer"},
+            )
+            if is_wildcat(cls):
+                setup_warnings_for_dangerous_dict_subclass_operations(cls)
 
         set_struc_converter(cls, converter)
         set_unstruc_converter(cls, converter)

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -1,12 +1,13 @@
 """Utilities for using attrs types with cattrs"""
 
+import enum
 import typing as ty
 from functools import partial
 
 import attr
 import cattrs
 
-from .attrs_shim import FieldTransformer, make_disallow_empties_transformer
+from .attrs_shim import make_disallow_empties_transformer
 from .converter import TypecatsConverter
 from .wildcat import (
     mixin_wildcat_post_attrs_methods,
@@ -148,7 +149,6 @@ def Cat(
     auto_attribs: bool = ...,
     disallow_empties: bool = ...,
     converter: TypecatsConverter = ...,
-    field_transformer: FieldTransformer | None = None,
     **kwargs: ty.Any,
 ) -> ty.Type[C]: ...
 
@@ -166,7 +166,6 @@ def Cat(
     auto_attribs: bool = ...,
     disallow_empties: bool = ...,
     converter: TypecatsConverter = ...,
-    field_transformer: FieldTransformer | None = None,
     **kwargs: ty.Any,
 ) -> ty.Callable[[ty.Type[C]], ty.Type[C]]: ...
 
@@ -176,7 +175,6 @@ def Cat(
     auto_attribs=True,
     disallow_empties=True,
     converter: TypecatsConverter = _TYPECATS_DEFAULT_CONVERTER,
-    field_transformer: FieldTransformer | None = None,
     **kwargs,
 ):
     """A Cat knows how to take care of itself.
@@ -205,21 +203,32 @@ def Cat(
 
     """
 
-    def _would_attrs_produce_fields(cls) -> bool:
-        return attr.has(cls) or bool(cls.__dict__.get("__annotations__", {}))
+    # Classes that are incompatible with attr.attrs() when they have no fields.
+    # Enum: attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
+    _SKIP_ATTRS_IF_FIELDLESS = (enum.Enum,)
+
+    def _skip_attrs(cls) -> bool:
+        return issubclass(cls, _SKIP_ATTRS_IF_FIELDLESS) and not (
+            attr.has(cls) or cls.__dict__.get("__annotations__")
+        )
 
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
-        if _would_attrs_produce_fields(cls):
-            cls = attr.attrs(
-                cls,
-                auto_attribs=auto_attribs,
-                field_transformer=make_disallow_empties_transformer(
-                    disallow_empties, field_transformer
-                ),
-                **kwargs,
-            )
-            if is_wildcat(cls):
-                setup_warnings_for_dangerous_dict_subclass_operations(cls)
+        if _skip_attrs(cls):
+            set_struc_converter(cls, converter)
+            set_unstruc_converter(cls, converter)
+            return cls
+
+        user_transformer = kwargs.get("field_transformer")
+        cls = attr.attrs(
+            cls,
+            auto_attribs=auto_attribs,
+            field_transformer=make_disallow_empties_transformer(
+                disallow_empties, user_transformer
+            ),
+            **{k: v for k, v in kwargs.items() if k != "field_transformer"},
+        )
+        if is_wildcat(cls):
+            setup_warnings_for_dangerous_dict_subclass_operations(cls)
 
         set_struc_converter(cls, converter)
         set_unstruc_converter(cls, converter)

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -205,12 +205,10 @@ def Cat(
 
     # Classes that are incompatible with attr.attrs() when they have no fields.
     # Enum: attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
-    _SKIP_ATTRS_IF_FIELDLESS = (enum.Enum,)
+    _CLASSES_INCOMPATIBLE_WITH_ATTRS = (enum.Enum,)
 
     def _skip_attrs(cls) -> bool:
-        return issubclass(cls, _SKIP_ATTRS_IF_FIELDLESS) and not (
-            attr.has(cls) or cls.__dict__.get("__annotations__")
-        )
+        return issubclass(cls, _CLASSES_INCOMPATIBLE_WITH_ATTRS)
 
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
         if _skip_attrs(cls):

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "typecats"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
#### New unit tests - Results BEFORE changes
```
====================================== short test summary info =======================================
FAILED tests/test_behavioral.py::test_cat_enum_structures_by_value - TypeError("EnumType.__call__() missing 1 required positional argument: 'value'") [single exceptio...
FAILED tests/test_behavioral.py::test_cat_enum_structures_nested_in_cat - TypeError("EnumType.__call__() missing 1 required positional argument: 'value'") [single exceptio...
FAILED tests/test_behavioral.py::test_cat_enum_with_int_values - TypeError("EnumType.__call__() missing 1 required positional argument: 'value'") [single exceptio...
FAILED tests/test_behavioral.py::test_cat_enum_with_annotations_structures_by_value - TypeError("EnumType.__call__() missing 1 required positional argument: 'value'") [single exceptio...
==================================== 4 failed, 84 passed in 0.10s ====================================
```

#### New unit tests - Results AFTER changes
```
======================================== test session starts =========================================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jp/Documents/Code/typecats
configfile: pyproject.toml
plugins: cov-7.0.0
collected 88 items                                                                                   

tests/test_behavioral.py ..........................................                            [ 47%]
tests/test_cats.py ........                                                                    [ 56%]
tests/test_dispatch_collision.py ..                                                            [ 59%]
tests/test_exceptions.py .....                                                                 [ 64%]
tests/test_funcs.py .                                                                          [ 65%]
tests/test_gen_converter.py ....                                                               [ 70%]
tests/test_python_39.py .                                                                      [ 71%]
tests/test_strip_defaults.py .......                                                           [ 79%]
tests/test_try_struc.py ..                                                                     [ 81%]
tests/test_unstruc_any.py ..                                                                   [ 84%]
tests/test_validators.py ....                                                                  [ 88%]
tests/test_wildcats.py ..........                                                              [100%]

========================================= 88 passed in 0.11s =========================================
```