### PR TITLE
OP-3579: enhance mypy plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ New features:
 
 - **Mypy plugin delegates to attrs** — `@Cat` classes are now fully understood as attrs classes by mypy (field reordering, frozen semantics, `AttrsInstance` protocol, `__attrs_attrs__`), in addition to the existing `.struc()`, `.try_struc()`, and `.unstruc()` signatures.
 - **`CatT` TypeVar** — new public `TypeVar` bounded by `attr.AttrsInstance`, for writing generic functions over Cat types.
-- **`is_wildcat` type narrowing** — accepts instances in addition to classes, with `TypeIs[attr.AttrsInstance]` overloads for static type narrowing.
-
-Dependencies:
-
-- Added `typing_extensions >=4.10.0`
-
 
 ## v2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 New features:
 
-- **Mypy plugin delegates to attrs** — `@Cat` classes are now fully understood as attrs classes by mypy (field reordering, frozen semantics, `AttrsInstance` protocol, `__attrs_attrs__`), in addition to the existing `.struc()`, `.try_struc()`, and `.unstruc()` signatures.
-- **`CatT` TypeVar** — new public `TypeVar` bounded by `attr.AttrsInstance`, for writing generic functions over Cat types.
+- **Improved mypy support** — `@Cat` classes are now recognized as full attrs classes by mypy, fixing false positives with `attr.fields()`, field validators, frozen inheritance, and default ordering.
+- **`CatT` TypeVar** — new public `TypeVar` for typing generic functions that operate on `@Cat` types. Import with `from typecats import CatT`.
 
 ## v2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.2.0
+
+New features:
+
+- **Mypy plugin delegates to attrs** — `@Cat` classes are now fully understood as attrs classes by mypy (field reordering, frozen semantics, `AttrsInstance` protocol, `__attrs_attrs__`), in addition to the existing `.struc()`, `.try_struc()`, and `.unstruc()` signatures.
+- **`CatT` TypeVar** — new public `TypeVar` bounded by `attr.AttrsInstance`, for writing generic functions over Cat types.
+- **`is_wildcat` type narrowing** — accepts instances in addition to classes, with `TypeIs[attr.AttrsInstance]` overloads for static type narrowing.
+
+Dependencies:
+
+- Added `typing_extensions >=4.10.0`
+
 ## v2.1.1
 
 Bug fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "typecats"
 description = "Structure unstructured data for the purpose of static type checking"
 authors = [{name = "Peter Gaultney", email = "pgaultney@xoi.io"}]
-version = "2.1.2"
+version = "2.2.0"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "attrs >=25.4.0,<27.0.0",
     "cattrs >=26.1.0,<27.0.0",
+    "typing_extensions >=4.10.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
     "attrs >=25.4.0,<27.0.0",
     "cattrs >=26.1.0,<27.0.0",
-    "typing_extensions >=4.10.0",
 ]
 
 [project.urls]

--- a/typecats/__init__.py
+++ b/typecats/__init__.py
@@ -14,10 +14,12 @@ from .tc import (
     unstruc_strip_defaults,
     set_detailed_validation_mode_not_threadsafe,
 )
+from .types import CatT
 from .wildcat import is_wildcat
 
 __all__ = [
     "Cat",
+    "CatT",
     "StructuringError",
     "set_default_exception_hook",
     "TypeCat",

--- a/typecats/cats_mypy_plugin.py
+++ b/typecats/cats_mypy_plugin.py
@@ -5,6 +5,10 @@ fully understood as attrs classes (field reordering, frozen semantics,
 AttrsInstance protocol, __attrs_attrs__, etc.), then layers on the
 .struc(), .try_struc(), and .unstruc() method signatures.
 
+The runtime @Cat decorator skips attrs processing for certain base
+classes (e.g. enum.Enum). The plugin mirrors this by deriving the
+skip list from the same CLASSES_INCOMPATIBLE_WITH_ATTRS constant.
+
 To enable, add to your pyproject.toml:
 
     [tool.mypy]
@@ -31,7 +35,10 @@ from mypy.plugins.attrs import (  # pylint: disable=no-name-in-module
     attr_class_maker_callback,
     attr_tag_callback,
 )
-from mypy.plugins.common import add_method  # pylint: disable=no-name-in-module
+from mypy.plugins.common import (  # pylint: disable=no-name-in-module
+    _get_decorator_bool_argument,
+    add_method,
+)
 from mypy.typeops import fill_typevars  # pylint: disable=no-name-in-module
 from mypy.types import (  # pylint: disable=no-name-in-module
     AnyType,
@@ -40,11 +47,17 @@ from mypy.types import (  # pylint: disable=no-name-in-module
     UnionType,
 )
 
+from typecats.tc import CLASSES_INCOMPATIBLE_WITH_ATTRS
+
 _CAT_FULLNAMES = frozenset(
     {
         "typecats.Cat",
         "typecats.tc.Cat",
     },
+)
+
+_SKIP_ATTRS_FULLNAMES = frozenset(
+    f"{cls.__module__}.{cls.__qualname__}" for cls in CLASSES_INCOMPATIBLE_WITH_ATTRS
 )
 
 
@@ -57,7 +70,7 @@ class CatsPlugin(Plugin):
         self, fullname: str
     ) -> Callable[[ClassDefContext], None] | None:
         if fullname in _CAT_FULLNAMES:
-            return attr_tag_callback
+            return _cat_tag_callback
         return None
 
     def get_class_decorator_hook_2(
@@ -68,9 +81,36 @@ class CatsPlugin(Plugin):
         return None
 
 
+def _should_skip_attrs(ctx: ClassDefContext) -> bool:
+    """Check whether the class inherits from a base that is incompatible
+    with attrs, mirroring the runtime _skip_attrs check in tc.py."""
+    for info in ctx.cls.info.mro:
+        if info.fullname in _SKIP_ATTRS_FULLNAMES:
+            return True
+    return False
+
+
+def _cat_tag_callback(ctx: ClassDefContext) -> None:
+    """Tag @Cat classes for the attrs plugin, unless they inherit from
+    an incompatible base (e.g. Enum)."""
+    if not _should_skip_attrs(ctx):
+        attr_tag_callback(ctx)
+
+
 def _cat_class_maker_callback(ctx: ClassDefContext) -> bool:
-    """Run the attrs plugin first, then add Cat-specific methods."""
-    ok = attr_class_maker_callback(ctx, auto_attribs_default=True)
+    """Run the attrs plugin for @Cat classes, then add Cat-specific methods.
+
+    The auto_attribs argument is extracted from the decorator call when
+    present, defaulting to True (matching the runtime @Cat default).
+    Classes that inherit from incompatible bases (e.g. Enum) skip the
+    attrs plugin entirely but still get struc/try_struc/unstruc.
+    """
+    if _should_skip_attrs(ctx):
+        _add_cat_methods(ctx)
+        return True
+
+    auto_attribs = _get_decorator_bool_argument(ctx, "auto_attribs", True)
+    ok = attr_class_maker_callback(ctx, auto_attribs_default=auto_attribs)
     if ok:
         _add_cat_methods(ctx)
     return ok

--- a/typecats/cats_mypy_plugin.py
+++ b/typecats/cats_mypy_plugin.py
@@ -1,7 +1,9 @@
 """Mypy plugin for typecats.
 
-Adds .struc(), .try_struc(), and .unstruc() method signatures to all
-@Cat-decorated classes so mypy understands their types.
+Delegates to mypy's built-in attrs plugin so that @Cat classes are
+fully understood as attrs classes (field reordering, frozen semantics,
+AttrsInstance protocol, __attrs_attrs__, etc.), then layers on the
+.struc(), .try_struc(), and .unstruc() method signatures.
 
 To enable, add to your pyproject.toml:
 
@@ -17,7 +19,6 @@ Or to mypy.ini:
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import override
 
 from mypy.nodes import (  # pylint: disable=no-name-in-module
     ARG_NAMED_OPT,
@@ -26,6 +27,10 @@ from mypy.nodes import (  # pylint: disable=no-name-in-module
     Var,
 )
 from mypy.plugin import ClassDefContext, Plugin  # pylint: disable=no-name-in-module
+from mypy.plugins.attrs import (  # pylint: disable=no-name-in-module
+    attr_class_maker_callback,
+    attr_tag_callback,
+)
 from mypy.plugins.common import add_method  # pylint: disable=no-name-in-module
 from mypy.typeops import fill_typevars  # pylint: disable=no-name-in-module
 from mypy.types import (  # pylint: disable=no-name-in-module
@@ -44,48 +49,56 @@ _CAT_FULLNAMES = frozenset(
 
 
 def plugin(_version: str) -> type[CatsPlugin]:
-    """Plugin for MyPy Typechecking of Cats"""
     return CatsPlugin
 
 
 class CatsPlugin(Plugin):
-    """A plugin to make MyPy understand Cats"""
+    def get_class_decorator_hook(
+        self, fullname: str
+    ) -> Callable[[ClassDefContext], None] | None:
+        if fullname in _CAT_FULLNAMES:
+            return attr_tag_callback
+        return None
 
-    @override
-    def get_class_decorator_hook(self, fullname: str) -> Callable[..., None] | None:
-        """One of the MyPy Plugin defined entry points"""
-        if fullname not in _CAT_FULLNAMES:
-            return None
+    def get_class_decorator_hook_2(
+        self, fullname: str
+    ) -> Callable[[ClassDefContext], bool] | None:
+        if fullname in _CAT_FULLNAMES:
+            return _cat_class_maker_callback
+        return None
 
-        def add_cat_methods(ctx: ClassDefContext) -> None:
-            any_type = AnyType(TypeOfAny.special_form)
-            str_type = ctx.api.named_type("builtins.str")
-            bool_type = ctx.api.named_type("builtins.bool")
-            dict_type = ctx.api.named_type("builtins.dict", [str_type, any_type])
-            mapping_type = ctx.api.named_type(
-                "collections.abc.Mapping", [str_type, any_type]
-            )
-            optional_mapping_type = UnionType([mapping_type, NoneType()])
-            cls_type = fill_typevars(ctx.cls.info)
 
-            d_arg = Argument(Var("d", mapping_type), mapping_type, None, ARG_POS)
-            d_opt_arg = Argument(
-                Var("d", optional_mapping_type), optional_mapping_type, None, ARG_POS
-            )
-            strip_arg = Argument(
-                Var("strip_defaults", bool_type), bool_type, None, ARG_NAMED_OPT
-            )
+def _cat_class_maker_callback(ctx: ClassDefContext) -> bool:
+    """Run the attrs plugin first, then add Cat-specific methods."""
+    ok = attr_class_maker_callback(ctx, auto_attribs_default=True)
+    if ok:
+        _add_cat_methods(ctx)
+    return ok
 
-            add_method(
-                ctx, "struc", args=[d_arg], return_type=cls_type, is_classmethod=True
-            )
-            add_method(
-                ctx,
-                "try_struc",
-                args=[d_opt_arg],
-                return_type=UnionType([cls_type, NoneType()]),
-                is_classmethod=True,
-            )
-            add_method(ctx, "unstruc", args=[strip_arg], return_type=dict_type)
 
-        return add_cat_methods
+def _add_cat_methods(ctx: ClassDefContext) -> None:
+    any_type = AnyType(TypeOfAny.special_form)
+    str_type = ctx.api.named_type("builtins.str")
+    bool_type = ctx.api.named_type("builtins.bool")
+    dict_type = ctx.api.named_type("builtins.dict", [str_type, any_type])
+    mapping_type = ctx.api.named_type("collections.abc.Mapping", [str_type, any_type])
+    optional_mapping_type = UnionType([mapping_type, NoneType()])
+    cls_type = fill_typevars(ctx.cls.info)
+
+    d_arg = Argument(Var("d", mapping_type), mapping_type, None, ARG_POS)
+    d_opt_arg = Argument(
+        Var("d", optional_mapping_type), optional_mapping_type, None, ARG_POS
+    )
+    strip_arg = Argument(
+        Var("strip_defaults", bool_type), bool_type, None, ARG_NAMED_OPT
+    )
+
+    add_method(ctx, "struc", args=[d_arg], return_type=cls_type, is_classmethod=True)
+    add_method(
+        ctx,
+        "try_struc",
+        args=[d_opt_arg],
+        return_type=UnionType([cls_type, NoneType()]),
+        is_classmethod=True,
+    )
+    add_method(ctx, "unstruc", args=[strip_arg], return_type=dict_type)

--- a/typecats/cats_mypy_plugin.py
+++ b/typecats/cats_mypy_plugin.py
@@ -28,6 +28,8 @@ from mypy.nodes import (  # pylint: disable=no-name-in-module
     ARG_NAMED_OPT,
     ARG_POS,
     Argument,
+    CallExpr,
+    NameExpr,
     Var,
 )
 from mypy.plugin import ClassDefContext, Plugin  # pylint: disable=no-name-in-module
@@ -35,10 +37,7 @@ from mypy.plugins.attrs import (  # pylint: disable=no-name-in-module
     attr_class_maker_callback,
     attr_tag_callback,
 )
-from mypy.plugins.common import (  # pylint: disable=no-name-in-module
-    _get_decorator_bool_argument,
-    add_method,
-)
+from mypy.plugins.common import add_method  # pylint: disable=no-name-in-module
 from mypy.typeops import fill_typevars  # pylint: disable=no-name-in-module
 from mypy.types import (  # pylint: disable=no-name-in-module
     AnyType,
@@ -47,7 +46,7 @@ from mypy.types import (  # pylint: disable=no-name-in-module
     UnionType,
 )
 
-from typecats.tc import CLASSES_INCOMPATIBLE_WITH_ATTRS
+from typecats.constants import CLASSES_INCOMPATIBLE_WITH_ATTRS
 
 _CAT_FULLNAMES = frozenset(
     {
@@ -97,6 +96,23 @@ def _cat_tag_callback(ctx: ClassDefContext) -> None:
         attr_tag_callback(ctx)
 
 
+def _get_bool_kwarg(ctx: ClassDefContext, name: str, default: bool) -> bool:
+    """Extract a boolean keyword argument from a decorator call.
+
+    Returns default if the decorator was applied without parentheses
+    (@Cat) or the argument was not provided (@Cat(other=...)).
+    """
+    if not isinstance(ctx.reason, CallExpr):
+        return default
+    for arg_name, arg_expr in zip(ctx.reason.arg_names, ctx.reason.args):
+        if arg_name == name and isinstance(arg_expr, NameExpr):
+            if arg_expr.fullname == "builtins.True":
+                return True
+            if arg_expr.fullname == "builtins.False":
+                return False
+    return default
+
+
 def _cat_class_maker_callback(ctx: ClassDefContext) -> bool:
     """Run the attrs plugin for @Cat classes, then add Cat-specific methods.
 
@@ -109,7 +125,7 @@ def _cat_class_maker_callback(ctx: ClassDefContext) -> bool:
         _add_cat_methods(ctx)
         return True
 
-    auto_attribs = _get_decorator_bool_argument(ctx, "auto_attribs", True)
+    auto_attribs = _get_bool_kwarg(ctx, "auto_attribs", True)
     ok = attr_class_maker_callback(ctx, auto_attribs_default=auto_attribs)
     if ok:
         _add_cat_methods(ctx)

--- a/typecats/constants.py
+++ b/typecats/constants.py
@@ -1,0 +1,13 @@
+"""Lightweight constants shared between runtime and the mypy plugin.
+
+This module must remain free of heavy imports (no cattrs, no converter
+creation) so the mypy plugin can import it without triggering runtime
+side effects.
+"""
+
+import enum
+import typing as ty
+
+CLASSES_INCOMPATIBLE_WITH_ATTRS: ty.Final = (
+    enum.Enum,  # attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
+)

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -24,6 +24,10 @@ from .exceptions import (
 from .strip_defaults import ShouldStripDefaults
 from .stack_context import stack_context
 
+CLASSES_INCOMPATIBLE_WITH_ATTRS: ty.Final = (
+    enum.Enum,  # attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
+)
+
 
 class TypeCat:
     """Base class that documents the interface added by the @Cat decorator.
@@ -203,12 +207,8 @@ def Cat(
 
     """
 
-    _CLASSES_INCOMPATIBLE_WITH_ATTRS = (
-        enum.Enum,  # attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
-    )
-
     def _skip_attrs(cls) -> bool:
-        return issubclass(cls, _CLASSES_INCOMPATIBLE_WITH_ATTRS)
+        return issubclass(cls, CLASSES_INCOMPATIBLE_WITH_ATTRS)
 
     def make_cat(cls: ty.Type[C]) -> ty.Type[C]:
         if _skip_attrs(cls):

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -1,6 +1,5 @@
 """Utilities for using attrs types with cattrs"""
 
-import enum
 import typing as ty
 from functools import partial
 
@@ -8,6 +7,7 @@ import attr
 import cattrs
 
 from .attrs_shim import make_disallow_empties_transformer
+from .constants import CLASSES_INCOMPATIBLE_WITH_ATTRS
 from .converter import TypecatsConverter
 from .wildcat import (
     mixin_wildcat_post_attrs_methods,
@@ -23,10 +23,6 @@ from .exceptions import (
 )
 from .strip_defaults import ShouldStripDefaults
 from .stack_context import stack_context
-
-CLASSES_INCOMPATIBLE_WITH_ATTRS: ty.Final = (
-    enum.Enum,  # attrs generates __call__(**{}) but EnumType.__call__ requires a value arg.
-)
 
 
 class TypeCat:

--- a/typecats/types.py
+++ b/typecats/types.py
@@ -1,6 +1,9 @@
 import typing as ty
 
+import attr
+
 C = ty.TypeVar("C")
+CatT = ty.TypeVar("CatT", bound=attr.AttrsInstance)
 StructureHook = ty.Callable[[ty.Any, ty.Type[C]], C]
 
 StrucInput = ty.Mapping[str, ty.Any]

--- a/typecats/types.py
+++ b/typecats/types.py
@@ -4,6 +4,17 @@ import attr
 
 C = ty.TypeVar("C")
 CatT = ty.TypeVar("CatT", bound=attr.AttrsInstance)
+"""TypeVar for generic functions that operate on @Cat types.
+
+Bounded by AttrsInstance rather than a Cat-specific protocol because
+@Cat is a decorator that produces attrs classes — it does not
+introduce its own type identity. @Cat classes are attrs classes at
+both runtime and in mypy's type system (via the cats_mypy_plugin).
+There is no narrower protocol that distinguishes @Cat from @attr.s
+because the struc/try_struc/unstruc methods are added dynamically
+by the decorator at runtime and by the plugin at analysis time,
+not through inheritance or a protocol.
+"""
 StructureHook = ty.Callable[[ty.Any, ty.Type[C]], C]
 
 StrucInput = ty.Mapping[str, ty.Any]

--- a/typecats/wildcat.py
+++ b/typecats/wildcat.py
@@ -3,10 +3,8 @@
 import typing as ty
 import logging
 
-import attr
 from attr import has as is_attrs_class
 from cattrs import Converter
-from typing_extensions import TypeIs
 
 from .attrs_shim import get_attrs_names
 
@@ -17,17 +15,7 @@ MWC = ty.TypeVar("MWC", bound=ty.MutableMapping)
 WC = ty.TypeVar("WC", bound=ty.Mapping)
 
 
-@ty.overload
-def is_wildcat(cls_or_obj: type) -> bool: ...
-@ty.overload
-def is_wildcat(cls_or_obj: object) -> TypeIs[attr.AttrsInstance]: ...
-
-
-def is_wildcat(cls_or_obj: object) -> bool:
-    if isinstance(cls_or_obj, type):
-        cls = cls_or_obj
-    else:
-        cls = type(cls_or_obj)
+def is_wildcat(cls: object) -> bool:
     core = ty.get_origin(cls) or cls
     if not isinstance(core, type):
         return False

--- a/typecats/wildcat.py
+++ b/typecats/wildcat.py
@@ -3,8 +3,11 @@
 import typing as ty
 import logging
 
+import attr
 from attr import has as is_attrs_class
 from cattrs import Converter
+from typing_extensions import TypeIs
+
 from .attrs_shim import get_attrs_names
 
 logger = logging.getLogger(__name__)
@@ -14,7 +17,17 @@ MWC = ty.TypeVar("MWC", bound=ty.MutableMapping)
 WC = ty.TypeVar("WC", bound=ty.Mapping)
 
 
-def is_wildcat(cls: object) -> bool:
+@ty.overload
+def is_wildcat(cls_or_obj: type) -> bool: ...
+@ty.overload
+def is_wildcat(cls_or_obj: object) -> TypeIs[attr.AttrsInstance]: ...
+
+
+def is_wildcat(cls_or_obj: object) -> bool:
+    if isinstance(cls_or_obj, type):
+        cls = cls_or_obj
+    else:
+        cls = type(cls_or_obj)
     core = ty.get_origin(cls) or cls
     if not isinstance(core, type):
         return False

--- a/uv.lock
+++ b/uv.lock
@@ -524,7 +524,6 @@ source = { editable = "." }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
-    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -542,7 +541,6 @@ dev = [
 requires-dist = [
     { name = "attrs", specifier = ">=25.4.0,<27.0.0" },
     { name = "cattrs", specifier = ">=26.1.0,<27.0.0" },
-    { name = "typing-extensions", specifier = ">=4.10.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -519,11 +519,12 @@ wheels = [
 
 [[package]]
 name = "typecats"
-version = "2.1.2"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -541,6 +542,7 @@ dev = [
 requires-dist = [
     { name = "attrs", specifier = ">=25.4.0,<27.0.0" },
     { name = "cattrs", specifier = ">=26.1.0,<27.0.0" },
+    { name = "typing-extensions", specifier = ">=4.10.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- **Improved mypy support** — `@Cat` classes are now recognized as full attrs classes by mypy, fixing false positives with `attr.fields()`, field validators, frozen inheritance, and default ordering.
- **`CatT` TypeVar** — new public `TypeVar` for typing generic functions that operate on `@Cat` types. Import with `from typecats import CatT`.
