### PR TITLE
OP-2976: feat: coerce mismatched types on setattr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3.0
+
+New features:
+
+- **Coerce on setattr** — `@Cat` fields auto-coerce mismatched values through the cattrs converter on assignment, preventing `unstruc()` crashes under cattrs 26+. Frozen classes are unaffected.
+
 ## v2.2.0
 
 New features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "typecats"
 description = "Structure unstructured data for the purpose of static type checking"
 authors = [{name = "Peter Gaultney", email = "pgaultney@xoi.io"}]
-version = "2.2.0"
+version = "2.3.0"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_coerce_on_setattr.py
+++ b/tests/test_coerce_on_setattr.py
@@ -1,0 +1,133 @@
+"""Tests for coercing values through cattrs on attribute assignment.
+
+Verifies that assigning a value of the wrong type to a Cat field
+(e.g. a str to an Optional[datetime] field) is coerced to the correct
+type, so that unstruc() does not crash under cattrs 26+.
+"""
+
+import typing as ty
+from datetime import datetime
+import attr
+import pytest
+from typecats import Cat, register_struc_hook, register_unstruc_hook
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _register_datetime_hooks():
+    register_struc_hook(
+        datetime, lambda s, _t: datetime.fromisoformat(s) if isinstance(s, str) else s
+    )
+    register_unstruc_hook(datetime, lambda d: d.isoformat() + "Z")
+
+
+@Cat
+class Job:
+    id: str = ""
+    completed_on: ty.Optional[datetime] = None
+    name: str = ""
+
+
+class TestStringAssignedToDatetimeFieldIsCoerced:
+    def test_assignment_coerces_str_to_datetime(self):
+        j = Job()
+        j.completed_on = "2026-04-24T21:41:52.733000"  # type: ignore[assignment]
+        assert isinstance(j.completed_on, datetime)
+
+    def test_unstruc_succeeds_after_str_assignment(self):
+        j = Job()
+        j.completed_on = "2026-04-24T21:41:52.733000"  # type: ignore[assignment]
+        result = j.unstruc()
+        assert isinstance(result["completed_on"], str)
+
+    def test_round_trip_preserves_value(self):
+        j = Job()
+        j.completed_on = "2026-04-24T21:41:52.733000"  # type: ignore[assignment]
+        result = j.unstruc()
+        j2 = Job.struc(result)
+        assert j2.completed_on is not None
+        assert j.completed_on is not None
+        assert j2.completed_on.replace(tzinfo=None) == j.completed_on.replace(
+            tzinfo=None
+        )
+
+
+class TestCorrectTypeAssignmentIsUnchanged:
+    def test_datetime_stays_datetime(self):
+        dt = datetime(2026, 4, 24, 21, 41, 52, 733000)
+        j = Job()
+        j.completed_on = dt
+        assert j.completed_on is dt
+
+    def test_none_stays_none(self):
+        j = Job()
+        j.completed_on = datetime(2026, 1, 1)
+        j.completed_on = None
+        assert j.completed_on is None
+
+    def test_str_to_str_field_unchanged(self):
+        j = Job()
+        j.name = "test"
+        assert j.name == "test"
+        assert isinstance(j.name, str)
+
+
+class TestNestedCatCoercion:
+    def test_dict_assigned_to_cat_field_is_structured(self):
+        @Cat
+        class Inner:
+            value: str
+
+        @Cat
+        class Outer:
+            inner: Inner = attr.Factory(lambda: Inner(value="default"))
+
+        o = Outer()
+        o.inner = {"value": "hello"}  # type: ignore[assignment]
+        assert isinstance(o.inner, Inner)
+        assert o.inner.value == "hello"
+        assert o.unstruc() == {"inner": {"value": "hello"}}
+
+
+class TestWildcatCoercion:
+    def test_wildcat_typed_field_is_coerced(self):
+        @Cat
+        class FieldUpdates(dict):
+            last_updated_on: datetime
+
+        fu = FieldUpdates.struc(
+            {"last_updated_on": "2026-04-24T21:41:52", "extra_key": "raw_string"}
+        )
+        assert isinstance(fu.last_updated_on, datetime)
+
+        fu.last_updated_on = "2026-05-01T00:00:00"  # type: ignore[assignment]
+        assert isinstance(fu.last_updated_on, datetime)
+
+
+class TestFrozenCatIsUnaffected:
+    def test_frozen_cat_still_rejects_setattr(self):
+        @Cat(frozen=True)
+        class Frozen:
+            x: str
+
+        f = Frozen.struc({"x": "hello"})
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            f.x = "world"  # type: ignore[misc]
+
+
+class TestCustomConverterCoercion:
+    def test_cat_with_custom_converter_coerces(self):
+        from typecats import TypecatsConverter
+
+        custom = TypecatsConverter()
+        custom.register_structure_hook(
+            datetime,
+            lambda s, _t: datetime.fromisoformat(s) if isinstance(s, str) else s,
+        )
+
+        @Cat(converter=custom)
+        class CustomJob:
+            done_at: ty.Optional[datetime] = None
+
+        j = CustomJob()
+        j.done_at = "2026-01-01T00:00:00"  # type: ignore[assignment]
+        assert isinstance(j.done_at, datetime)

--- a/typecats/coerce.py
+++ b/typecats/coerce.py
@@ -1,0 +1,48 @@
+"""on_setattr hook that coerces values through the cattrs converter on type mismatch."""
+
+import typing as ty
+
+import attr
+
+if ty.TYPE_CHECKING:
+    from .converter import TypecatsConverter
+
+
+def _unwrap_optional(field_type: type) -> type | None:
+    """Return the inner type if field_type is Optional[X], else None."""
+    origin = ty.get_origin(field_type)
+    if origin is ty.Union:
+        args = [a for a in ty.get_args(field_type) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return None
+
+
+def make_coerce_hook(
+    converter: "TypecatsConverter",
+) -> ty.Callable[[ty.Any, attr.Attribute, ty.Any], ty.Any]:  # type: ignore[type-arg]
+    """Build an attrs on_setattr hook that structures mismatched values.
+
+    When a value is assigned to a Cat field and the value's runtime type does
+    not match the declared type, the converter structures the value into the
+    correct type. This prevents cattrs 26+ from crashing during unstructure
+    when it encounters, e.g., a str where a datetime is declared.
+    """
+
+    def _coerce(instance: ty.Any, attrib: attr.Attribute, new_value: ty.Any) -> ty.Any:  # type: ignore[type-arg]
+        if new_value is None:
+            return new_value
+
+        field_type = attrib.type
+        if field_type is None:
+            return new_value
+
+        inner = _unwrap_optional(field_type)
+        check_type = inner if inner is not None else field_type
+
+        if isinstance(new_value, check_type):
+            return new_value
+
+        return converter.structure(new_value, check_type)
+
+    return _coerce

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -9,6 +9,7 @@ import cattrs
 from .attrs_shim import make_disallow_empties_transformer
 from .constants import CLASSES_INCOMPATIBLE_WITH_ATTRS
 from .converter import TypecatsConverter
+from .coerce import make_coerce_hook
 from .wildcat import (
     mixin_wildcat_post_attrs_methods,
     setup_warnings_for_dangerous_dict_subclass_operations,
@@ -213,13 +214,28 @@ def Cat(
             return cls
 
         user_transformer = kwargs.get("field_transformer")
+        is_frozen = kwargs.get("frozen", False)
+        passthrough_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in ("field_transformer", "on_setattr")
+        }
+        if not is_frozen:
+            user_on_setattr = kwargs.get("on_setattr")
+            coerce_hook = make_coerce_hook(converter)
+            passthrough_kwargs["on_setattr"] = (
+                attr.setters.pipe(coerce_hook, user_on_setattr)
+                if user_on_setattr is not None
+                and user_on_setattr is not attr.setters.NO_OP
+                else coerce_hook
+            )
         cls = attr.attrs(
             cls,
             auto_attribs=auto_attribs,
             field_transformer=make_disallow_empties_transformer(
                 disallow_empties, user_transformer
             ),
-            **{k: v for k, v in kwargs.items() if k != "field_transformer"},
+            **passthrough_kwargs,
         )
         if is_wildcat(cls):
             setup_warnings_for_dangerous_dict_subclass_operations(cls)

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "typecats"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- `@Cat` fields now auto-coerce mismatched values through the cattrs converter on attribute assignment using the native attrs `on_setattr` hook
- Prevents `unstruc()` crashes under cattrs 26+, which generates type-specific unstructure hooks that assume field values match their declared types
- Frozen classes are unaffected

## Context

cattrs 26 changed `Optional[datetime]` unstructure from runtime-type dispatch (old: passes `str` through silently) to declared-type dispatch (new: calls `iso8601strict(dt)` which crashes on `str`). Any code that assigns a raw value to a typed Cat field without structuring it first now fails at unstructure time.

## Test plan

- [x] String assigned to `Optional[datetime]` field is coerced to `datetime`
- [x] `unstruc()` succeeds after coerced assignment
- [x] Round-trip (assign str -> unstruc -> struc) preserves value
- [x] Correct-type assignment is a no-op (same object identity)
- [x] `None` assignment passes through unchanged
- [x] Nested Cat: dict assigned to Cat-typed field is structured
- [x] Wildcat typed field is coerced
- [x] Frozen Cat still rejects setattr
- [x] Custom converter is used for coercion
- [x] All 98 existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)