### PR TITLE
OP-2976: fix subscripted generic TypeError in coerce hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3.1
+
+Bug fixes:
+
+- Fix `TypeError` in coerce hook for fields annotated with subscripted generics (e.g. `Dict[str, Optional[X]]`).
+
 ## v2.3.0
 
 New features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "typecats"
 description = "Structure unstructured data for the purpose of static type checking"
 authors = [{name = "Peter Gaultney", email = "pgaultney@xoi.io"}]
-version = "2.3.0"
+version = "2.3.1"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_coerce_on_setattr.py
+++ b/tests/test_coerce_on_setattr.py
@@ -103,6 +103,38 @@ class TestWildcatCoercion:
         assert isinstance(fu.last_updated_on, datetime)
 
 
+class TestSubscriptedGenericFields:
+    def test_dict_field_with_generic_type_is_not_coerced(self):
+        @Cat
+        class Container:
+            data: ty.Dict[str, ty.Optional[int]] = attr.Factory(dict)
+
+        c = Container()
+        d = {"a": 1, "b": None}
+        c.data = d
+        assert c.data is d
+
+    def test_list_field_with_generic_type_is_not_coerced(self):
+        @Cat
+        class Container:
+            items: ty.List[ty.Optional[str]] = attr.Factory(list)
+
+        c = Container()
+        items = ["a", None, "b"]
+        c.items = items
+        assert c.items is items
+
+    def test_unstruc_works_with_generic_fields(self):
+        @Cat
+        class Container:
+            data: ty.Dict[str, int] = attr.Factory(dict)
+
+        c = Container()
+        c.data = {"x": 1}
+        result = c.unstruc()
+        assert result == {"data": {"x": 1}}
+
+
 class TestFrozenCatIsUnaffected:
     def test_frozen_cat_still_rejects_setattr(self):
         @Cat(frozen=True)

--- a/typecats/coerce.py
+++ b/typecats/coerce.py
@@ -40,7 +40,13 @@ def make_coerce_hook(
         inner = _unwrap_optional(field_type)
         check_type = inner if inner is not None else field_type
 
-        if isinstance(new_value, check_type):
+        # Subscripted generics (e.g. Dict[str, X]) can't be used with isinstance.
+        # Use the origin type for the check, or skip if there is none.
+        origin = ty.get_origin(check_type)
+        if origin is not None:
+            if isinstance(new_value, origin):
+                return new_value
+        elif isinstance(check_type, type) and isinstance(new_value, check_type):
             return new_value
 
         return converter.structure(new_value, check_type)

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "typecats"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- Fix `TypeError: Subscripted generics cannot be used with class and instance checks` when assigning to fields typed as `Dict[str, X]`, `List[Optional[X]]`, etc.
- Uses `get_origin()` to check against the origin type (`dict`, `list`, etc.) instead of the subscripted form

## Context

Follow-up to #27. The coerce hook called `isinstance(value, Dict[str, Optional[X]])` which is illegal in Python 3.12+.

## Test plan

- [x] `Dict[str, Optional[int]]` field assignment passes through without error
- [x] `List[Optional[str]]` field assignment passes through without error
- [x] `unstruc()` works after assigning to generic-typed fields
- [x] All 101 tests pass

Generated with [Claude Code](https://claude.com/claude-code)