### PR TITLE
OP-2976: fix inherited frozen on_setattr conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3.2
+
+Bug fixes:
+
+- Fix `ValueError: Frozen classes can't use on_setattr` when a `@Cat` inherits from a frozen parent.
+
 ## v2.3.1
 
 Bug fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "typecats"
 description = "Structure unstructured data for the purpose of static type checking"
 authors = [{name = "Peter Gaultney", email = "pgaultney@xoi.io"}]
-version = "2.3.1"
+version = "2.3.2"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_coerce_on_setattr.py
+++ b/tests/test_coerce_on_setattr.py
@@ -145,6 +145,21 @@ class TestFrozenCatIsUnaffected:
         with pytest.raises(attr.exceptions.FrozenInstanceError):
             f.x = "world"  # type: ignore[misc]
 
+    def test_child_of_frozen_cat_can_be_defined(self):
+        @Cat(frozen=True)
+        class FrozenParent:
+            x: str
+
+        @Cat
+        class FrozenChild(FrozenParent):
+            y: int = 0
+
+        c = FrozenChild.struc({"x": "hello", "y": 1})
+        assert c.x == "hello"
+        assert c.y == 1
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            c.y = 2  # type: ignore[misc]
+
 
 class TestCustomConverterCoercion:
     def test_cat_with_custom_converter_coerces(self):

--- a/typecats/tc.py
+++ b/typecats/tc.py
@@ -26,6 +26,14 @@ from .strip_defaults import ShouldStripDefaults
 from .stack_context import stack_context
 
 
+def _is_frozen(cls: type, kwargs: dict[str, ty.Any]) -> bool:
+    """Check if the resulting attrs class will be frozen."""
+    if kwargs.get("frozen", False):
+        return True
+    props = getattr(cls, "__attrs_props__", None)
+    return props is not None and props.is_frozen
+
+
 class TypeCat:
     """Base class that documents the interface added by the @Cat decorator.
 
@@ -214,7 +222,7 @@ def Cat(
             return cls
 
         user_transformer = kwargs.get("field_transformer")
-        is_frozen = kwargs.get("frozen", False)
+        is_frozen = _is_frozen(cls, kwargs)
         passthrough_kwargs = {
             k: v
             for k, v in kwargs.items()

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "typecats"
-version = "2.3.1"
+version = "2.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- Fix `ValueError: Frozen classes can't use on_setattr` when a `@Cat` inherits from a `@Cat(frozen=True)` parent
- Uses `__attrs_props__.is_frozen` (public attrs metadata) to detect inherited frozen

## Context

Follow-up to #27/#28. The `is_frozen` check only looked at `kwargs.get("frozen")`, missing the case where frozen is inherited from a parent attrs class.

## Test plan

- [x] `@Cat` child of `@Cat(frozen=True)` parent can be defined
- [x] Child still rejects setattr (inherits frozen behavior)
- [x] All 102 tests pass

Generated with [Claude Code](https://claude.com/claude-code)